### PR TITLE
Update/Form Input

### DIFF
--- a/site/components/Input/Input.vue
+++ b/site/components/Input/Input.vue
@@ -2,7 +2,7 @@
   <div class="form__item"
       :class="{
         'has-error': errors.has(name_default),
-        'has-extras': hasExtrasSlot,
+        'has-extras has-action': hasActionSlot,
         'dropdown-with-input': dropdown_options
     }">
     <!--<o-dropdown v-if="dropdown_options" :id="dropdown_options.id" :value="dropdown_value" :items="dropdown_options.items" :label="dropdown_options.label" :placeholder="dropdown_options.label" @input="updateDropdownValue" />-->
@@ -15,8 +15,8 @@
            autocomplete="off" v-on="input_listeners">
     <label class="form__label" :for="id">{{ label }}</label>
 
-    <div v-if="hasExtrasSlot" class="form__extras">
-      <slot name="extras"></slot>
+    <div v-if="hasActionSlot" class="form__action">
+      <slot name="action"></slot>
     </div>
 
     <p v-if="errors.has(name_default)" class="form__message">{{ errors.first(name_default) }}</p>
@@ -162,8 +162,8 @@ export default {
       )
     },
 
-    hasExtrasSlot () {
-      return this.$slots.extras
+    hasActionSlot () {
+      return this.$slots.action
     }
   },
 

--- a/site/components/Input/Input.vue
+++ b/site/components/Input/Input.vue
@@ -5,27 +5,22 @@
         'has-extras': hasExtrasSlot,
         'dropdown-with-input': dropdown_options
     }">
-    <div class="form__wrapper" :class="[ { 'is-loading is-loading--medium': is_loading } ]">
-      <o-dropdown v-if="dropdown_options" :id="dropdown_options.id" :value="dropdown_value" :items="dropdown_options.items" :label="dropdown_options.label" :placeholder="dropdown_options.label" @input="updateDropdownValue" />
+    <!--<o-dropdown v-if="dropdown_options" :id="dropdown_options.id" :value="dropdown_value" :items="dropdown_options.items" :label="dropdown_options.label" :placeholder="dropdown_options.label" @input="updateDropdownValue" />-->
 
-      <div class="form__input-wrapper">
-        <input class="form__input" :id="id" ref="input" v-validate="validate" :type="type"
-               :class="{ 'is-full': input_value || input_value === 0, 'has-placeholder': placeholder }"
-               :name="name_default" :placeholder="placeholder"  :data-vv-delay="validate_delay"
-               :disabled="disabled" :value="input_value" :readonly="read_only" :data-vv-validate-on="validate_on"
-               :data-vv-as="validate_name_default" :min="min" :max="max"
-               autocomplete="off" v-on="input_listeners">
-        <label class="form__label" :for="id">{{ label }}</label>
+    <input class="form__input" :id="id" ref="input" v-validate="validate" :type="type"
+           :class="{ 'is-full': input_value || input_value === 0, 'has-placeholder': placeholder }"
+           :name="name_default" :placeholder="placeholder"  :data-vv-delay="validate_delay"
+           :disabled="disabled" :value="input_value" :readonly="read_only" :data-vv-validate-on="validate_on"
+           :data-vv-as="validate_name_default" :min="min" :max="max"
+           autocomplete="off" v-on="input_listeners">
+    <label class="form__label" :for="id">{{ label }}</label>
 
-        <div v-if="hasExtrasSlot" class="form__extras">
-          <slot name="extras"></slot>
-        </div>
-      </div>
+    <div v-if="hasExtrasSlot" class="form__extras">
+      <slot name="extras"></slot>
     </div>
 
-    <div v-if="errors.has(name_default)" class="form__message">{{ errors.first(name_default) }}</div>
-    <div v-if="description" class="form__description">{{ description}}</div>
-
+    <p v-if="errors.has(name_default)" class="form__message">{{ errors.first(name_default) }}</p>
+    <p v-if="description" class="form__description">{{ description}}</p>
   </div>
 </template>
 

--- a/site/pages/docs/components/form/input.vue
+++ b/site/pages/docs/components/form/input.vue
@@ -158,7 +158,7 @@
           validate_name="Email address"
         >
 
-          <o-button text="send message" size="small" slot="extras" />
+          <o-button text="send message" size="small" slot="action" />
 
         </o-input>
       </form>
@@ -172,7 +172,7 @@
             <div class="form__input-wrapper">
               <input id="form_large_button_read_only" type="text" name="form_large_button_read_only" readonly="readonly" class="form__input is-full" value="1231231231231231">
               <label for="form_large_button_read_only" class="form__label">Your API key</label>
-              <div class="form__extras">
+              <div class="form__action">
                 <button type="button" class="button button--small">
                   copy to clipboard
                 </button>
@@ -194,7 +194,7 @@
           :read_only="true"
         >
 
-          <o-button text="copy to clipboard" size="small" slot="extras" />
+          <o-button text="copy to clipboard" size="small" slot="action" />
 
         </o-input>
       </form>
@@ -585,7 +585,7 @@ export default {
     validate_name="Email address"
   >
 
-    <o-button text="send message" size="small" slot="extras" />
+    <o-button text="send message" size="small" slot="action" />
 
   </o-input>
 </form>`,
@@ -598,7 +598,7 @@ export default {
     :read_only="true"
   >
 
-    <o-button text="copy to clipboard" size="small" slot="extras" />
+    <o-button text="copy to clipboard" size="small" slot="action" />
 
   </o-input>
 </form>`,
@@ -607,7 +607,7 @@ export default {
     <input id="form_large_button_read_only" type="text" name="form_large_button_read_only" readonly="readonly" class="form__input is-full" value="cw8BT7BcJzZQqlnwGZ53XD3cdfEXArGs">
     <label for="form_large_button_read_only" class="form__label">Your API key</label>
 
-    <div class="form__extras">
+    <div class="form__action">
       <button type="button" class="button button--small">
         copy to clipboard
       </button>

--- a/site/pages/docs/components/form/input.vue
+++ b/site/pages/docs/components/form/input.vue
@@ -21,7 +21,7 @@
             </div>
           </div>
 
-          <div class="form__description">Description text</div>
+          <p class="form__description">Description text</p>
         </div>
       </form>
     </docs-item>
@@ -36,8 +36,6 @@
         />
       </form>
     </docs-item>
-
-
 
     <!-- Validation  -->
     <docs-item title="Validation - required" :code="input_validation_small" v-if="!is_html">
@@ -54,8 +52,6 @@
       </form>
     </docs-item>
 
-
-
     <!-- Validation with rules  -->
     <docs-item title="Validation - required with rules" :code="input_validation_rules_small" v-if="!is_html">
       <form class="form" slot="body">
@@ -69,8 +65,6 @@
         />
       </form>
     </docs-item>
-
-
 
     <!-- Read-only  -->
     <docs-item title="Read-only" :code="input_validation_read_only_html" v-if="!is_html">
@@ -96,8 +90,6 @@
       </form>
     </docs-item>
 
-
-
     <!-- Size Large  -->
     <docs-item title="Large" :code="input_large_html" v-if="!is_html">
       <form class="form form--large" slot="body">
@@ -108,7 +100,7 @@
               <label for="form_large" class="form__label">Label</label>
             </div>
           </div>
-          <div class="form__description">Description text</div>
+          <p class="form__description">Description text</p>
         </div>
       </form>
     </docs-item>
@@ -187,7 +179,7 @@
               </div>
             </div>
           </div>
-          <div class="form__description">To change your API key please contact support</div>
+          <p class="form__description">To change your API key please contact support</p>
         </div>
       </form>
     </docs-item>
@@ -207,7 +199,6 @@
         </o-input>
       </form>
     </docs-item>
-
 
     <!-- Large with a placeholder  -->
     <docs-item title="Large with a placeholder" :code="input_placeholder_large" v-if="!is_html">
@@ -509,13 +500,9 @@ export default {
 </form>`,
       input_html: `<form class="form">
   <div class="form__item">
-    <div class="form__wrapper">
-      <div class="form__input-wrapper">
-        <input id="form_id" type="text" name="form_id" placeholder="Label" class="form__input">
-      </div>
-    </div>
+    <input id="form_id" type="text" name="form_id" placeholder="Label" class="form__input">
 
-    <div class="form__description">Description text</div>
+    <p class="form__description">Description text</p>
   </div>
 </form>`,
 
@@ -550,11 +537,7 @@ export default {
 </form>`,
       input_validation_read_only_html: `<form class="form">
   <div class="form__item">
-    <div class="form__wrapper">
-      <div class="form__input-wrapper">
-        <input id="form_read_only" type="text" name="form_read_only" placeholder="Label" readonly="readonly" class="form__input">
-      </div>
-    </div>
+    <input id="form_read_only" type="text" name="form_read_only" placeholder="Label" readonly="readonly" class="form__input">
   </div>
 </form>`,
 
@@ -568,13 +551,9 @@ export default {
 </form>`,
       input_large_html: `<form class="form form--large">
   <div class="form__item">
-    <div class="form__wrapper">
-      <div class="form__input-wrapper">
-        <input id="form_large" type="text" name="form_large" class="form__input">
-        <label for="form_large" class="form__label">Label</label>
-      </div>
-    </div>
-    <div class="form__description">Description text</div>
+    <input id="form_large" type="text" name="form_large" class="form__input">
+    <label for="form_large" class="form__label">Label</label>
+    <p class="form__description">Description text</p>
   </div>
 </form>`,
 
@@ -590,12 +569,8 @@ export default {
 </form>`,
       input_read_only_large: `<form class="form form--large" slot="body">
   <div class="form__item">
-    <div class="form__wrapper">
-      <div class="form__input-wrapper">
-        <input id="form_large_read_only" type="text" name="form_large_read_only" readonly="readonly" class="form__input">
-        <label for="form_large_read_only" class="form__label">Label</label>
-      </div>
-    </div>
+    <input id="form_large_read_only" type="text" name="form_large_read_only" readonly="readonly" class="form__input">
+    <label for="form_large_read_only" class="form__label">Label</label>
   </div>
 </form>`,
 
@@ -629,18 +604,16 @@ export default {
 </form>`,
       input_large_read_only_button_html: `<form class="form form--large">
   <div class="form__item has-extras">
-    <div class="form__wrapper">
-      <div class="form__input-wrapper">
-        <input id="form_large_button_read_only" type="text" name="form_large_button_read_only" readonly="readonly" class="form__input is-full" value="cw8BT7BcJzZQqlnwGZ53XD3cdfEXArGs">
-        <label for="form_large_button_read_only" class="form__label">Your API key</label>
-        <div class="form__extras">
-          <button type="button" class="button button--small">
-            copy to clipboard
-          </button>
-        </div>
-      </div>
+    <input id="form_large_button_read_only" type="text" name="form_large_button_read_only" readonly="readonly" class="form__input is-full" value="cw8BT7BcJzZQqlnwGZ53XD3cdfEXArGs">
+    <label for="form_large_button_read_only" class="form__label">Your API key</label>
+
+    <div class="form__extras">
+      <button type="button" class="button button--small">
+        copy to clipboard
+      </button>
     </div>
-    <div class="form__description">To change your API key please contact support</div>
+
+    <p class="form__description">To change your API key please contact support</p>
   </div>
 </form>`,
 

--- a/src/scss/src/components/_form.scss
+++ b/src/scss/src/components/_form.scss
@@ -27,7 +27,7 @@
 --------------------------------------------------*/
 
 .form__input-wrapper {
-  position: relative; 
+  position: relative;
   flex: 1;
 }
 
@@ -118,10 +118,10 @@
 }
 
 
-/** Form extras
+/** Form action
 --------------------------------------------------*/
 
-.form__extras {
+.form__extras, .form__action {
   height: $input-height;
   position: absolute;
   right: 0;
@@ -158,7 +158,7 @@
 --------------------------------------------------*/
 
 .form__item {
-  
+
   /** Error */
   &.has-error {
     .form__input,
@@ -166,9 +166,9 @@
       border-color: rgba(color('red'), 0.75);
     }
   }
-  
-  /** Extras */
-  &.has-extras {
+
+  /** Action */
+  &.has-extras, &.has-action {
     .form__input {
       &[readonly] {
         color: color('secondary');
@@ -193,7 +193,7 @@
       display: block;
     }
 
-    &.is-full, 
+    &.is-full,
     &.has-placeholder {
       padding: ($spacing-base * 1.5) ($spacing-base / 2) ($spacing-base / 2);
 
@@ -216,7 +216,7 @@
     }
   }
 
-  .form__extras {
+  .form__extras, .form__action {
     height: $input-height-large;
   }
 }


### PR DESCRIPTION
Remove unnecessary wrappers around input and label. Wrapper was used when dropdown was positioned beside Input. We'll add it back once we support dropdown together with input.
Change description tag from `<div>` to `<p>` and update classes to keep consistency over all orange components